### PR TITLE
Pin base image by digest; add OIDC migration TODO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 .DS_Store
+
+# Local AWS credentials (temporary STS tokens written by `npm run credentials`).
+# Must never be committed — see README dev-credentials section.
+credentials.json
+.aws/
+
 # Logs
 logs
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,15 @@
 # Test:   docker build --target test -t s3proxy:test . && docker run --rm s3proxy:test
 # Run:    docker run -e BUCKET=my-bucket -p 8080:8080 forkzero/s3proxy
 
-# s3proxy requires Node >= 22.13. Pin by digest in CI via Dependabot updates.
-ARG NODE_VERSION=22-alpine
-
 ########################################################################
 # base: OS packages, production dependencies, and the app. Shared by all
 # stages and, on its own, the runnable production image.
 ########################################################################
-FROM node:${NODE_VERSION} AS base
+# Node 22 on Alpine (s3proxy requires Node >= 22.13), pinned by digest for
+# reproducible builds. This is the multi-arch manifest-list digest, so the
+# amd64 + arm64 publish both resolve from it. Dependabot (docker ecosystem,
+# weekly) bumps the tag + digest when a new 22-alpine ships.
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS base
 
 ARG VERSION
 WORKDIR /src

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,98 @@
+# TODO
+
+## Migrate CI AWS auth to GitHub OIDC (remove long-lived keys)
+
+**Why:** CI currently authenticates to S3 with a static access key from the IAM
+user `s3proxy-docker-ci`, stored as the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+repo secrets. Long-lived keys work until manually rotated and stay valid if ever
+leaked. OIDC lets GitHub Actions assume an IAM **role** for short-lived
+credentials per run — nothing persistent to leak or rotate.
+
+**Scope:** one-time AWS setup + a `ci.yml` change + deleting the static user.
+
+### 1. Register GitHub's OIDC provider in AWS (once per account)
+
+Skip if it already exists (`aws iam list-open-id-connect-providers`).
+
+```bash
+aws iam create-open-id-connect-provider \
+  --url https://token.actions.githubusercontent.com \
+  --client-id-list sts.amazonaws.com \
+  --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+```
+
+### 2. Create the role with the same least-privilege policy + a repo-scoped trust policy
+
+Trust policy — only this repo's workflows may assume the role (`trust.json`):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::624920530251:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:forkzero/s3proxy-docker:*"
+        }
+      }
+    }
+  ]
+}
+```
+
+```bash
+aws iam create-role \
+  --role-name s3proxy-docker-ci \
+  --assume-role-policy-document file://trust.json \
+  --description "GitHub OIDC role for s3proxy-docker CI (least-privilege S3 read)"
+
+# Reuse the exact same S3 policy already used by the static user:
+#   s3:ListBucket on arn:aws:s3:::s3proxy-public
+#   s3:GetObject  on arn:aws:s3:::s3proxy-public/*
+aws iam put-role-policy \
+  --role-name s3proxy-docker-ci \
+  --policy-name s3proxy-public-read \
+  --policy-document file://ci-policy.json
+```
+
+Tighten `sub` later if desired, e.g. `repo:forkzero/s3proxy-docker:ref:refs/heads/main`
+or `:pull_request`.
+
+### 3. Switch `.github/workflows/ci.yml`
+
+- Add job-level permissions to the `test` and `docker` jobs:
+  ```yaml
+  permissions:
+    id-token: write   # mint the OIDC token
+    contents: read
+  ```
+- Replace the credential inputs in the `configure-aws-credentials@v4` step with:
+  ```yaml
+  with:
+    role-to-assume: arn:aws:iam::624920530251:role/s3proxy-docker-ci
+    aws-region: us-east-1
+  ```
+  (drop `aws-access-key-id` / `aws-secret-access-key`; `aws-region` can stay a
+  literal or move to a repo **variable** since it's no longer secret.)
+
+### 4. Tear down the static credential
+
+```bash
+aws iam list-access-keys --user-name s3proxy-docker-ci   # note the AccessKeyId
+aws iam delete-access-key  --user-name s3proxy-docker-ci --access-key-id <AKID>
+aws iam delete-user-policy --user-name s3proxy-docker-ci --policy-name s3proxy-public-read
+aws iam delete-user        --user-name s3proxy-docker-ci
+# Remove the now-unused repo secrets:
+gh secret delete AWS_ACCESS_KEY_ID     --repo forkzero/s3proxy-docker
+gh secret delete AWS_SECRET_ACCESS_KEY --repo forkzero/s3proxy-docker
+```
+
+Verify a CI run is green **before** deleting the user/keys, so there's a rollback.


### PR DESCRIPTION
## Digest pin (reproducible builds)
Pins the base image from the floating `node:22-alpine` tag to
`node:22-alpine@sha256:16e22a55…` — the **multi-arch manifest-list** digest, so
both `amd64` and `arm64` in `publish.yml` resolve from it. This makes builds
reproducible and stops silent upstream drift; **Dependabot** (docker ecosystem,
already configured weekly) opens a PR to bump the tag+digest on new releases.
Dropped the now-redundant `NODE_VERSION` build-arg (kept inline in `FROM` so
Dependabot reliably matches it).

Verified: `docker build --target production` succeeds against the pinned digest.

## OIDC migration TODO
Adds `TODO.md` writing up the follow-up: move CI AWS auth from the static
`s3proxy-docker-ci` access key to **GitHub OIDC** (register the OIDC provider,
create a repo-scoped IAM role reusing the same least-privilege S3 policy, switch
`ci.yml` to `role-to-assume` + `id-token: write`, then delete the static user
and the `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets). No long-lived keys
once done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)