### PR TITLE
Adopt s3proxy 4.2 fetchWeb()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hono/node-server": "^2.0.0",
         "hono": "^4.12.15",
-        "s3proxy": "^4.1.0"
+        "s3proxy": "^4.2.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4"
@@ -1854,9 +1854,9 @@
       }
     },
     "node_modules/s3proxy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/s3proxy/-/s3proxy-4.1.0.tgz",
-      "integrity": "sha512-X5BakRUgtSEBwMY2rTt8XfB+4hTxEEiPKBsD6cKMG1Ox0xYCXq/rjlhZofUrUEjARPE3kuffWrX0xrO+SlacSg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/s3proxy/-/s3proxy-4.2.0.tgz",
+      "integrity": "sha512-P4CXF7IEJj/n8FOZSqrVrf9I1YWLFt7XQ9Ybjw0+1tbJtCs6lOWpQCaG4NnWAnptXJKlVgrRwfG3mZEbWCWu1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.832.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "s3proxy-docker",
   "description": "Docker runtime for s3proxy (Hono)",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "type": "module",
   "engines": {
     "node": ">=22.13.0"
@@ -28,9 +28,9 @@
     "deps:check": "npm outdated"
   },
   "dependencies": {
-    "s3proxy": "^4.1.0",
+    "@hono/node-server": "^2.0.0",
     "hono": "^4.12.15",
-    "@hono/node-server": "^2.0.0"
+    "s3proxy": "^4.2.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4"

--- a/server.js
+++ b/server.js
@@ -14,7 +14,6 @@
 
 import fs from 'node:fs'
 import process from 'node:process'
-import { Readable } from 'node:stream'
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
 import { S3Proxy } from 's3proxy'
@@ -83,19 +82,10 @@ app.get('/version', (c) =>
 
 app.get('/', (c) => c.redirect('/index.html', 301))
 
-// Stream every key straight from S3. proxy.fetch() throws a typed S3ProxyError
-// on classified failures (404/403/416), which is handled by app.onError below.
-app.on(['GET', 'HEAD'], '/*', async (c) => {
-  const url = new URL(c.req.url)
-  const { stream, status, headers } = await proxy.fetch({
-    url: url.pathname + url.search,
-    method: c.req.method,
-    headers: Object.fromEntries(c.req.raw.headers),
-  })
-  // Node Readable → Web ReadableStream; backpressure propagates, no buffering.
-  const body = Readable.toWeb(stream)
-  return new Response(body, { status, headers })
-})
+// Stream every key straight from S3. fetchWeb() (s3proxy >= 4.2) adapts the Web
+// Request → Response and throws a typed S3ProxyError on classified failures
+// (404/403/416), which is handled by app.onError below.
+app.on(['GET', 'HEAD'], '/*', (c) => proxy.fetchWeb(c.req.raw))
 
 // Render errors as XML, matching the s3proxy Express/Fastify examples.
 app.onError((error, c) => {


### PR DESCRIPTION
s3proxy **4.2** shipped `fetchWeb(request: Request): Promise<Response>` — the Web-standard adapter proposed in gmoon/s3proxy#142. This adopts it.

## Change
The GET/HEAD handler collapses from the hand-rolled `fetch()` + URL/header adaptation + `Readable.toWeb()` block to one line:

```js
app.on(['GET', 'HEAD'], '/*', (c) => proxy.fetchWeb(c.req.raw))
```

`fetchWeb` throws the typed `S3ProxyError` on classified failures (404/403/416), so `app.onError` still renders the XML error body. The `node:stream` import is now unused and removed.

- `s3proxy` → `^4.2.0`; repo version → `4.2.0`.

## Verification
Against `s3proxy-public`:
- GET `/index.html` → 200 `text/html` 338 B; HEAD `/large.bin` → 200, `content-length` 10485760; GET Range 0-99 → 206, 100 B; missing key → 404 `application/xml`.
- Unit tests (`test:app`) 4/4.
- **s3-website-test-kit** conformance + health suites: **0 failures** (parity with the pre-`fetchWeb` image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)