### PR TITLE
publish: tag latest on release (latest=auto)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE }}
+          # latest=auto tags `latest` for the newest non-prerelease semver
+          # release, and applies nothing spurious on a bare workflow_dispatch.
+          flavor: latest=auto
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
The `latest` image tag in `publish.yml` was gated on `enable={{is_default_branch}}`, which is **false** on a release/tag event. A release would therefore push `X.Y.Z` and `X.Y` but **not** `latest`, breaking the README's bare `forkzero/s3proxy` (= `latest`) references.

Switch to `flavor: latest=auto`: tags `latest` for the newest non-prerelease semver release, and applies nothing spurious on a bare `workflow_dispatch`.

Needed before cutting the first release so `forkzero/s3proxy:latest` is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)