### PR TITLE
chore: upgrade @forkzero/s3-website-test-kit to ^0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@forkzero/s3-website-test-kit": "^0.2.0",
+        "@forkzero/s3-website-test-kit": "^0.2.1",
         "artillery": "^2.0.33"
       },
       "engines": {
@@ -1316,9 +1316,9 @@
       }
     },
     "node_modules/@forkzero/s3-website-test-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@forkzero/s3-website-test-kit/-/s3-website-test-kit-0.2.0.tgz",
-      "integrity": "sha512-9nNsxFju3iWMOQE37Qbxl51v6EvTtUbxFHojaD6OLCA1BKz26hoA4xYtDCLag3N6+b+cxgL+tWo4PUheSt6cdg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@forkzero/s3-website-test-kit/-/s3-website-test-kit-0.2.1.tgz",
+      "integrity": "sha512-/VDfJoomJxDX0FAJbNt0CzoYt1WNc536p2Ia4m0wC4b0i+BpH+2AujYdVSZMpT14+R12VnCmR23KckReg135CA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@forkzero/s3-website-test-kit": "^0.2.0",
+    "@forkzero/s3-website-test-kit": "^0.2.1",
     "artillery": "^2.0.33"
   },
   "keywords": [


### PR DESCRIPTION
Bumps the test kit devDependency `^0.2.0` → `^0.2.1`.

All referenced config/scenario paths are unchanged. Conformance gate verified green against the built production image:

```
plugins.expect.ok: 16
vusers.completed: 1
vusers.failed: 0   (exit 0)
```

(0.2.1's suite has 16 expect assertions vs 17 in 0.2.0 — one fewer `contentType` check upstream, not a regression here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)