### PR TITLE
fix(deps): upgrade s3proxy to 4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hono/node-server": "^2.0.0",
         "hono": "^4.12.15",
-        "s3proxy": "^4.2.0"
+        "s3proxy": "^4.2.1"
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -6276,9 +6276,9 @@
       }
     },
     "node_modules/s3proxy": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/s3proxy/-/s3proxy-4.2.0.tgz",
-      "integrity": "sha512-P4CXF7IEJj/n8FOZSqrVrf9I1YWLFt7XQ9Ybjw0+1tbJtCs6lOWpQCaG4NnWAnptXJKlVgrRwfG3mZEbWCWu1w==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/s3proxy/-/s3proxy-4.2.1.tgz",
+      "integrity": "sha512-63IPm1SdkU7X3TA4r0TLeI1yiFPE6eFQeibJONklojXHLSjt/wbVJiqNgyiIsno6ih98wbxheqPeCDWwAhCO+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.832.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@hono/node-server": "^2.0.0",
     "hono": "^4.12.15",
-    "s3proxy": "^4.2.0"
+    "s3proxy": "^4.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
Bumps the bundled `s3proxy` dependency `^4.2.0` → `^4.2.1` (lockfile `4.2.0` → `4.2.1`).

4.2.1 is a docs-only s3proxy release (no functional change vs 4.2.0), so the image behavior is identical — but rebuilding against it makes `/version` report `4.2.1` and keeps the published `forkzero/s3proxy` image in lockstep with the library.

`fix:` so release-please cuts a matching **4.2.1** image release; merging the resulting release PR builds + pushes `forkzero/s3proxy:4.2.1` / `:4.2` / `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)