### PR TITLE
fix: upgrade base image and CI to Node 24 (Active LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci --no-audit --no-fund
       - run: npm run lint
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci --no-audit --no-fund
       - run: npm run test:app
@@ -60,7 +60,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       # Dev deps (artillery + the test kit) power the container tests and the
       # conformance gate below.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@
 # base: OS packages, production dependencies, and the app. Shared by all
 # stages and, on its own, the runnable production image.
 ########################################################################
-# Node 22 on Alpine (s3proxy requires Node >= 22.13), pinned by digest for
-# reproducible builds. This is the multi-arch manifest-list digest, so the
-# amd64 + arm64 publish both resolve from it. Dependabot (docker ecosystem,
-# weekly) bumps the tag + digest when a new 22-alpine ships.
-FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS base
+# Node 24 (Active LTS) on Alpine (s3proxy requires Node >= 22.13), pinned by
+# digest for reproducible builds. This is the multi-arch manifest-list digest,
+# so the amd64 + arm64 publish both resolve from it. Dependabot (docker
+# ecosystem, weekly) bumps the tag + digest when a new 24-alpine ships.
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS base
 
 ARG VERSION
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Or via the `Makefile`: `make build`, `make lint`, `make test`, `make docker-test
 
 The [`Dockerfile`](./Dockerfile) is a multi-stage build:
 
-- **`base`** – Alpine + Node 22, production dependencies, and `server.js`.
+- **`base`** – Alpine + Node 24, production dependencies, and `server.js`.
   Runs as the non-root `node` user with `tini` as PID 1 for clean signal
   handling. This is the runnable image.
 - **`test`** – adds dev dependencies and the full source, runs `npm test`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "artillery": "^2.0.33"
       },
       "engines": {
-        "node": ">=22.13.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@artilleryio/int-commons": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "4.2.1",
   "type": "module",
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=24.0.0"
   },
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Why

Node 22 ("Jod") entered **Maintenance LTS in October 2025**; **Node 24 is now the Active LTS line**. The image was on 22 only by inertia — it was pinned there and nothing moved it. `s3proxy` requires Node `>=22.13`, which 24 satisfies, so there's no dependency blocker to moving up.

## Changes

- **`Dockerfile`** — base image `node:22-alpine` → `node:24-alpine`, repinned to the current multi-arch manifest-list digest (`sha256:a0b9bf06…`). Verified the digest resolves to a manifest list containing `linux/amd64` + `linux/arm64` (the two platforms this image publishes). Comment updated.
- **`.github/workflows/ci.yml`** — `node-version: 22` → `24` across the lint, test, and docker jobs.
- **`package.json`** — engines floor `>=22.13.0` → `>=24.0.0`, with the root entry in `package-lock.json` synced to match. The `@forkzero/s3-website-test-kit` dependency's own `>=22.13.0` engines entry is left untouched.
- **`README.md`** — image-layout note updated to "Alpine + Node 24".

## Dependabot

No change needed. `.github/dependabot.yml` has no version pins or ignore rules for the docker ecosystem — the docker updater follows whatever tag is in the `FROM` line. Now that it reads `24-alpine`, Dependabot tracks the 24 line automatically (digest bumps for `24-alpine`, and it will propose `25-alpine` when that ships).

## Verification

The new digest was confirmed to be a valid multi-arch (amd64 + arm64) manifest list. The image build and lint were not run in this environment (no Docker daemon, dependencies not installed) — CI will exercise the full build, container smoke test, and conformance gate on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9JaRJUSWGNKrMJ2vqAAw1)_